### PR TITLE
Undef HAVE_CONFIG_H for Fribidi workaround

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -19,7 +19,7 @@ build:
 
 build_script:
   # build the library 
-  - cmake -DUNIT_TEST=1 -DWANT_DEBUG=1 -DSTATIC_LIB=1 -DRAQM_DEPENS_DIR:PATH="win/raqm-dependencies/build/dependencies"
+  - cmake -DUNIT_TEST=1 -DWANT_DEBUG=1 -DSTATIC_LIB=1 -DRAQM_DEPENS_DIR:PATH="win/raqm-dependencies/build/dependencies" .
   # build the library for Release and Debug
   - cmake --build . --config Debug 
   - ctest -C "Debug"

--- a/src/raqm.c
+++ b/src/raqm.c
@@ -24,6 +24,7 @@
 
 #ifdef HAVE_CONFIG_H
 #include "config.h"
+#undef HAVE_CONFIG_H  // Workaround for Fribidi 1.0.5 and earlier
 #endif
 #include <assert.h>
 #include <string.h>


### PR DESCRIPTION
On macOS 10.14.4,
```
[master]:libraqm-cmake andrewmurray$ cmake .
-- The C compiler identification is AppleClang 10.0.1.10010046
-- The CXX compiler identification is AppleClang 10.0.1.10010046
-- Check for working C compiler: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc
-- Check for working C compiler: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++
-- Check for working CXX compiler: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Performing Test C99_SUPPORTED
-- Performing Test C99_SUPPORTED - Success
-- Found Freetype: /opt/local/lib/libfreetype.dylib (found version "2.10.0") 
-- FreeType2 Library Found OK: /opt/local/lib/libfreetype.dylib
-- Found PkgConfig: /opt/local/bin/pkg-config (found version "0.29.2") 
-- Checking for module 'glib-2.0'
--   Found glib-2.0, version 2.58.3
-- Looking for fribidi_utf8_to_unicode
-- Looking for fribidi_utf8_to_unicode - found
-- Found FriBiDi: /opt/local/lib/libfribidi.dylib
-- Checking for module 'harfbuzz>=0.9.20'
--   Found harfbuzz, version 2.3.1
-- Harfbuzz Library Found OK:  /opt/local/lib/libharfbuzz.dylib 
-- Found HarfBuzz: /opt/local/include/harfbuzz  
-- build without documentation
-- Configuring done
-- Generating done
-- Build files have been written to: /Users/andrewmurray/Desktop/libraqm-cmake
[master.]:libraqm-cmake andrewmurray$ make
Scanning dependencies of target raqm
[ 50%] Building C object CMakeFiles/raqm.dir/src/raqm.c.o
In file included from /Users/andrewmurray/Desktop/libraqm-cmake/src/raqm.c:31:
In file included from /opt/local/include/fribidi/fribidi.h:31:
In file included from /opt/local/include/fribidi/fribidi-unicode.h:32:
/opt/local/include/fribidi/fribidi-types.h:31:11: fatal error: 'config.h' file not found
# include <config.h>
          ^~~~~~~~~~
1 error generated.
make[2]: *** [CMakeFiles/raqm.dir/src/raqm.c.o] Error 1
make[1]: *** [CMakeFiles/raqm.dir/all] Error 2
make: *** [all] Error 2
```

Looks like HAVE_CONFIG_H is being defined by raqm, and then read by fribidi, which doesn't have a config.h

While this has been corrected by https://github.com/fribidi/fribidi/issues/85 and https://github.com/fribidi/fribidi/commit/b534ab2642f694c3106d5bc8d0a8beae60bf60d3, a new version of fribidi hasn't been released yet, and I presume that you are interested in making this work with the existing versions of fribidi anyway.

So this PR undefs HAVE_CONFIG_H once raqm is finished with it.